### PR TITLE
Removed duplicate property

### DIFF
--- a/tools/tomcat/archaius.properties
+++ b/tools/tomcat/archaius.properties
@@ -31,10 +31,6 @@ hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=1000
 # default: true
 hystrix.command.default.execution.isolation.thread.interruptOnTimeout=true
 
-# How long should Hystrix wait for a response?
-# default: 1000
-hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=1000
-
 # How many errors are allowed before the circuit breaker is activated?
 # default: 50 (must be greater than 0,
 # 100 means no breaking despite of errors)


### PR DESCRIPTION
The property 'hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds' was duplicated in the file.
